### PR TITLE
fix: remove unused ModalAction type export

### DIFF
--- a/app/ui/composites/modal.ts
+++ b/app/ui/composites/modal.ts
@@ -1,7 +1,7 @@
 import { escapeHtml } from "../../shared/dom.js";
 import { captureFocusReturn } from "../core/a11y.js";
 
-export interface ModalAction {
+interface ModalAction {
     label: string;
     tone?: string;
     dataAction?: string;


### PR DESCRIPTION
## Summary

Removes `export` from `ModalAction` interface — it is only used internally within `modal.ts` (`ModalProps.actions` array type). Zero external consumers across FortWeb and Fort-ios.

- typecheck: pass
- build:runtime: pass
- Knip: ModalAction finding gone